### PR TITLE
v7.0.2

### DIFF
--- a/options/wpwebapp-security.php
+++ b/options/wpwebapp-security.php
@@ -85,7 +85,7 @@
 						</div>
 					<?php endif; ?>
 					<label>
-						<input type="checkbox" name="wpwebapp_force_password_reset" id="wpwebapp_force_password_reset" value="on" <?php checked( $force_reset, 'on' ); ?> <?php checked( $force_reset, '' ); ?>>
+						<input type="checkbox" name="wpwebapp_force_password_reset" id="wpwebapp_force_password_reset" value="on" <?php checked( $force_reset, 'on' ); ?>>
 						<?php _e( 'Force user to reset their password at next login', 'photoboard_user_groups' ); ?>
 					</label>
 				</td>

--- a/wordpress-for-web-apps.php
+++ b/wordpress-for-web-apps.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://github.com/cferdinandi/wordpress-for-web-apps/
  * GitHub Plugin URI: https://github.com/cferdinandi/wordpress-for-web-apps/
  * Description: Transform WordPress into a web app engine. Adjust your settings under <a href="options-general.php?page=wpwebapp_plugin_options">Web App Options</a>.
- * Version: 7.0.1
+ * Version: 7.0.2
  * Author: Chris Ferdinandi
  * Author URI: http://gomakethings.com
  * License: MIT


### PR DESCRIPTION
Removed default to forced reset when creating a user manually via the Dashboard (since they need to create their own password anyways)